### PR TITLE
Fix Language Display on Class 5 Buttons

### DIFF
--- a/active-handout.yml
+++ b/active-handout.yml
@@ -1,7 +1,7 @@
 
 theme:
   name: active-handout-theme
-  locale: pt_BR
+  locale: en
 
 docs_dir: content
 site_dir: docs


### PR DESCRIPTION
This PR addresses the language display issue in Class 5 as described in [Issue #1](https://github.com/Insper/mlops/issues/1). The locale field in the active-handout.yml file was updated to en, ensuring that the "Submit Answer" and "Mark as Done" buttons now correctly display in English, consistent with the rest of the website.

Changes Made:

Updated the locale field in active-handout.yml from Portuguese (pt-BR) to English (en).

Linked Issue:

Closes #1