### PR TITLE
fix: change python3 version from 3.10 to 3.12 in lambda handouts

### DIFF
--- a/content/classes/07-lambda/lambda_layer.md
+++ b/content/classes/07-lambda/lambda_layer.md
@@ -48,7 +48,7 @@ Then, install the version of Python used by your Lambda functions and the ZIP:
 
     ```console
     $ apt update
-    $ apt install python3.10 python3-pip zip
+    $ apt install python3.12 python3-pip zip
     ```
 
 </div>
@@ -60,8 +60,8 @@ Create a folder to store the dependencies and install then:
 <div class="termy">
 
     ```console
-    $ mkdir -p layer/python/lib/python3.10/site-packages
-    $ pip3 install textblob -t layer/python/lib/python3.10/site-packages
+    $ mkdir -p layer/python/lib/python3.12/site-packages
+    $ pip3 install textblob -t layer/python/lib/python3.12/site-packages
 
     ```
 
@@ -434,7 +434,7 @@ lambda_client = boto3.client(
 
 # Fetch the layer version ARN based on the layer name
 response = lambda_client.list_layer_versions(
-    CompatibleRuntime="python3.10",  # Provide the compatible runtime of the layer
+    CompatibleRuntime="python3.12",  # Provide the compatible runtime of the layer
     LayerName=layer_name,
 )
 

--- a/content/classes/07-lambda/sa_lambda_function.md
+++ b/content/classes/07-lambda/sa_lambda_function.md
@@ -173,7 +173,7 @@ with open("polarity.zip", "rb") as f:
 
 lambda_response = lambda_client.create_function(
     FunctionName=function_name,
-    Runtime="python3.10", # Change the runtime if you want!
+    Runtime="python3.12", # Change the runtime if you want!
     Role=lambda_role_arn,
     Handler="polarity.get_polarity",  # function get_polarity inside polarity.py
     Code={"ZipFile": zip_to_deploy},


### PR DESCRIPTION
This PR adresses the issue described in #3 